### PR TITLE
Fix Oracle PList generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings/
 .idea/
 jarbundler-parent.iml
+.DS_Store
+target/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Take a look at [./docs/index.html](http://htmlpreview.github.io/?https://github.
 # ChangeLog
 
 ## Version 3.4.0 (2018-08-xx)
+* optional `useOracleStyle` attribute to generate the Plist Java entries in Oracle format
 * Support for Java 9+ in `jvmversion` attribute
 
 ## Version 3.3.0 (2015-11-09)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Take a look at [./docs/index.html](http://htmlpreview.github.io/?https://github.
 
 # ChangeLog
 
+## Version 3.4.0 (2018-08-xx)
+* Support for Java 9+ in `jvmversion` attribute
+
 ## Version 3.3.0 (2015-11-09)
 * Merged changes from [tofi86/Jarbundler](https://github.com/tofi86/Jarbundler/) into official release
   * optional `contentSize` attribute *(for Plist key `NSPreferencesContentSize`)*

--- a/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
@@ -69,6 +69,9 @@ public class AppBundleProperties {
 	// Support for JavaX key, optional
 	private boolean mJavaXKey = false;
 
+	// Support for Oracle Plist style, optional
+	private boolean mOracleStyle = false;
+
 	// Explicit default: JavaApplicationStub
 	private String mCFBundleExecutable = "JavaApplicationStub";
 
@@ -131,7 +134,7 @@ public class AppBundleProperties {
 	/**
 	 * LSEnvironment (Dictionary - OS X) defines environment variables to be set before launching this app. The names of the environment variables are the keys of the dictionary, with the values being the corresponding environment variable value. Both keys and values must be strings.
 	 * These environment variables are set only for apps launched through Launch Services. If you run your executable directly from the command line, these environment variables are not set.
-	 * 
+	 *
 	 * @author Tobias Bley
 	 * @since 3.2.0
 	 */
@@ -142,10 +145,10 @@ public class AppBundleProperties {
 
 	/**
 	 * Add a LSEnvironment key-value pair to the mLSEnvironments hashtable.
-	 * 
+	 *
 	 * @author Tobias Bley
 	 * @since 3.2.0
-	 * 
+	 *
 	 * @param key A Key
 	 * @param value A Value
 	 */
@@ -155,10 +158,10 @@ public class AppBundleProperties {
 
 
 	/**
-	 * 
+	 *
 	 * @author Tobias Bley
 	 * @since 3.2.0
-	 * 
+	 *
 	 * @return LSEnvironment
 	 */
 	public Hashtable getLSEnvironment() {
@@ -167,7 +170,7 @@ public class AppBundleProperties {
 
 	/**
 	 * Add a Java runtime property to the properties hashtable.
-	 * 
+	 *
 	 * @param prop A property
 	 * @param val A value
 	 */
@@ -214,7 +217,7 @@ public class AppBundleProperties {
 
 	/**
 	 * Add a document type to the document type list.
-	 * 
+	 *
 	 * @param documentType A document type
 	 */
 	public void addDocumentType(DocumentType documentType) {
@@ -231,7 +234,7 @@ public class AppBundleProperties {
 
 	/**
 	 * Add a service to the services list.
-	 * 
+	 *
 	 * @param service Service
 	 */
 	public void addService(Service service) {
@@ -355,6 +358,14 @@ public class AppBundleProperties {
 
 	public boolean getJavaXKey() {
 		return mJavaXKey;
+	}
+
+	public void setOracleStyle(boolean b) {
+		mOracleStyle = b;
+	}
+
+	public boolean getOracleStyle() {
+		return mOracleStyle;
 	}
 
 	public void setCFBundleExecutable(String s) {

--- a/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
@@ -438,7 +438,14 @@ public class AppBundleProperties {
 
 	public void setJVMVersion(String s) {
 		mJVMVersion = s;
-		mJavaVersion = Double.parseDouble(s.substring(0, 3));
+
+		if(s.startsWith("1.")) {
+			// parse Java versions up to 1.8
+			mJavaVersion = Double.parseDouble(s.substring(0, 3));
+		} else {
+			// parse Java versions 9 and higher (9, 9-ea, 9+, 9.1, 10, 10.0, 11, 11*, 11.13, etc.)
+			mJavaVersion = Double.parseDouble(s.replaceAll("^(9|\\d\\d)(\\.\\d\\d?)?.*$", "$1$2"));
+		}
 	}
 
 	public String getJVMVersion() {

--- a/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
@@ -505,10 +505,26 @@ public class JarBundler extends MatchingTask {
 	 * @param b True sets 'JavaX' dictionary key instead of 'Java' key
 	 */
 	public void setUseJavaXKey(boolean b) {
-		if (b && (bundleProperties.getJavaVersion() >= 1.7)) {
-			throw new BuildException("Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used");
+		if (b && bundleProperties.getOracleStyle()) {
+			throw new BuildException("Setting attribute 'useJavaXKey' is useless if attribute 'useOracleStyle' is used");
 		}
 		bundleProperties.setJavaXKey(b);
+	}
+
+	/**
+	 * <p>Setter for optional generation of Oracle Plist format</p>
+	 * <p>If this isn't set, the default Apple Plist Format will be used</p>
+	 * 
+	 * @author Tobias Fischer
+	 * @since 3.4.0
+	 * 
+	 * @param b True generates Oracle Plist format instead of Apple Plist format
+	 */
+	public void setUseOracleStyle(boolean b) {
+		if (b && bundleProperties.getJavaXKey()) {
+			throw new BuildException("Setting attribute 'useOracleStyle' is useless if attribute 'useJavaXKey' is used");
+		}
+		bundleProperties.setOracleStyle(b);
 	}
 
 	/**
@@ -625,8 +641,8 @@ public class JarBundler extends MatchingTask {
 	 */
 	public void setJvmversion(String s) {
 		bundleProperties.setJVMVersion(s);
-		if (bundleProperties.getJavaXKey() && (bundleProperties.getJavaVersion() >= 1.7)) {
-			throw new BuildException("Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used");
+		if (bundleProperties.getJavaVersion() > 1.6 && !(bundleProperties.getJavaXKey() || bundleProperties.getOracleStyle())) {
+			throw new BuildException("When requesting a JVM > 1.6 you should either set the 'useJavaXKey' attribute (to generate a compatible Apple Plist format) or the 'useOracleStyle' attribute (to generate an Oracle Plist format).");
 		}
 	}
 
@@ -1137,7 +1153,7 @@ public class JarBundler extends MatchingTask {
 					+ mResourcesDir);
 
 		// Make the Resources/Java directory
-		mJavaDir = new File(bundleProperties.getJavaVersion() < 1.7 ? mResourcesDir : mContentsDir, "Java");
+		mJavaDir = new File(bundleProperties.getOracleStyle()? mContentsDir: mResourcesDir, "Java");
 
 		if (!mJavaDir.mkdir())
 			throw new BuildException("Unable to create directory " + mJavaDir);

--- a/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
@@ -906,7 +906,7 @@ public class JarBundler extends MatchingTask {
 	 * @since 3.2.0
 	 * 
 	 * @param lsEnvironment A 'lsenvironment' element
-	 * @throws BuildException 'lsenvironment' must have both 'name' and 'value' attibutes
+	 * @throws BuildException 'lsenvironment' must have both 'name' and 'value' attributes
 	 */
 	public void addConfiguredLSEnvironment(LSEnvironment lsEnvironment) throws BuildException {
 
@@ -915,7 +915,7 @@ public class JarBundler extends MatchingTask {
 
 		if ((name == null) || (value == null))
 			throw new BuildException(
-					"'<lsenvironment>' must have both 'name' and 'value' attibutes");
+					"'<lsenvironment>' must have both 'name' and 'value' attributes");
 
 		bundleProperties.addLSEnvironment(name, value);
 	}
@@ -927,7 +927,7 @@ public class JarBundler extends MatchingTask {
 
 		if ((name == null) || (value == null))
 			throw new BuildException(
-					"'<javaproperty>' must have both 'name' and 'value' attibutes");
+					"'<javaproperty>' must have both 'name' and 'value' attributes");
 
 		bundleProperties.addJavaProperty(name, value);
 	}
@@ -941,7 +941,7 @@ public class JarBundler extends MatchingTask {
 
 		if ((name == null) || (role == null))
 			throw new BuildException(
-					"'<documenttype>' must have both a 'name' and a 'role' attibute");
+					"'<documenttype>' must have both a 'name' and a 'role' attribute");
 
 		if ((osTypes.isEmpty()) && (extensions.isEmpty()) && (mimeTypes.isEmpty()))
 			throw new BuildException(

--- a/core/src/main/java/com/ultramixer/jarbundler/PropertyListWriter.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/PropertyListWriter.java
@@ -278,9 +278,9 @@ public class PropertyListWriter
         }
 
         // Java / JavaX entries in the plist dictionary
-        if (bundleProperties.getJavaVersion() < 1.7)
+        if (bundleProperties.getOracleStyle() == false)
         {
-            // Apple Java Version
+            // Apple Java Version / legacy support for the Apple Java Dictionary via 'JavaX' key
             writeKey(bundleProperties.getJavaXKey() ? "JavaX" : "Java", dict);
             Node javaDict = createNode("dict", dict);
 


### PR DESCRIPTION
This PR contains changes made after the discussion in #8.

* 282fab8 Fix parsing of `jvmversion` to support Java 9+ (new *semver* versioning scheme)
* 0f68620 Introduce a new attribute `useOracleStyle` as an alternative to `useJavaXKey`

**What does the PR fix?**

With PR #8 @Vampire introduced and @tobium merged code changes that prevented the use of the `JavaX` key.

The new code would always use the Oracle PList syntax when a `jvmversion` > 1.7 was requested. However, with the `JavaX` key feature and e.g. the `universalJavaApplicationStub` as a launcher stub you can perfectly create App bundles wich run with Java 7, 8+. No need to fall back to the Oracle Plist style.

**What is the `JavaX` key for anyways?**

The JavaX key isn't standardized. It's supported by https://github.com/tofi86/universalJavaApplicationStub (~100 stars, ~30 clones a day), a project I created when Oracle took over Java development from Apple. The purpose was to have a launcher stub supporting the "old" `Java` key even on Java 7 and 8 because the new Oracle PList style didn't support all features.
Then with Java 8 Oracle started to show warning messages and redirecting Apps using the `Java` key to the old Java 6. Together with the original developer of JarBundler we came up with the idea of using a non-standard key named `JavaX` and I did the implementation in both projects (first in my fork of JarBundler, then merged here).

This is still relevant because the Oracle PList style didn't evolve (in contrary: Oracle discontinued their appbundler project) and the syntax still doesn't support all the features the Apple dictionary did. Call it "legacy" mode. In the meantime quite a bunch of tools use this feature frequently: https://github.com/search?q=usejavaxkey&type=Code

That's why the `useJavaXKey` attribute exists and should continue working in this project.

**Why is it implemented like it is?**

The changes from #8 were were merged after the 3.3 release but were never officially released on Maven Central.

Therefore I chose to refactor the Oracle Plist style implementation by @Vampire in a similar way to the `JavaX` implementation: As an additional attribute: `useOracleStyle`.

Here are a couple of annotated examples:

```xml
<jarbundler jvmversion="1.7+" …>
```
* Before (with PR #8): *Switched to the Oracle Plist style without notification in the build log*
* Now: *Continues to work as in v3.3.0. No auto switch to the Oracle Plist style. Creates the Apple Plist style with old `Java` dictionary.*

----

```xml
<jarbundler jvmversion="1.7+" useJavaXKey="true" …>
```
* Before (with PR #8): *Failed with Exception `Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used`*
* Now: *Continues to work as in v3.3.0. No auto switch to the Oracle Plist style. Creates the Apple Plist style in "legacy mode" with `JavaX` dictionary.*

----

```xml
<jarbundler jvmversion="1.7+" useJavaXKey="true" useOracleStyle="true" …>
```
* Before (with PR #8): *Failed with Exception `Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used`*
* Now: *Failes with Exception `Setting attribute 'useOracleStyle' is useless if attribute 'useJavaXKey' is used`*

----

```xml
<jarbundler jvmversion="1.7+" useOracleStyle="true" useJavaXKey="true" …>
```
* Before (with PR #8): *Failed with Exception `Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used`. *
* Now: *Failes with Exception `Setting attribute 'useJavaXKey' is useless if attribute 'useOracleStyle' is used`*

----

```xml
<jarbundler jvmversion="1.7+" useOracleStyle="true" …>
```
* Now: *Creates the Oracle Plist style.*

----

**Conclusion:**

With these changes we maintain backward compatibility to v3.3 and do not break existing build scripts due to explicit auto switch to Oracle Plist style.

However, if you'd like to use the Oracle PList format you can now set this option explicitly.

----

@Vampire @tobium I'd like to hear your comments and thoughts on that :-)

I'm very much looking forward to see this released as v3.4.0!!