### PR TITLE
modern java versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 jarbundler-parent.iml
 .DS_Store
 target/
+classes/
+jarbundler*.jar

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project name="jarbundler" default="jar" basedir=".">
 
-  <property name="version" value="2.3.2"/>
+  <property name="version" value="3.3.1"/>
   <property name="description" value="ANT task for creating Mac OS X application bundles"/>
 
 
@@ -12,14 +12,26 @@
 
   <!-- Needs to reference this in order to compile                     -->
   <!-- This path works only for OS X, Windows, and Linux must redefine -->
-  <property name="ant.jar" value="/Developer/Java/Ant/lib/ant.jar" />
+  <!-- <property name="ant.jar" value="/Developer/Java/Ant/lib/ant.jar" /> -->
 
 
   <target name="compile" description="Compile the classes">
 
     <mkdir dir="classes"/>
 
-    <javac srcdir="src" destdir="classes" source="1.6" classpath="${ant.jar}"/>
+    <!-- java 13 won't compile this with source=1.6. It moans about 1.7.
+         The first version it is silent about is 1,8, but for MacOS users
+         that has GUI problems. 9 is the first good version, so that's what
+         it is.
+      -->
+    <javac srcdir="core/src"
+           destdir="classes"
+           source="9"
+           deprecation="yes"
+           classpath="${ant.jar}"
+           includeAntRuntime="yes">
+           <!-- <compilerarg value="-Xlint:unchecked"/> -->
+    </javac>
   </target>
 
 
@@ -121,7 +133,7 @@
     <delete dir="build"/>
     <delete dir="javadoc"/>
     <delete dir="release"/>
-    <ant dir="example" target="clean" inheritAll="false"/>
+	<ant dir="examples" target="clean" inheritAll="false"/>
   </target>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.9.3</version>
+            <version>1.10.9</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/AppBundleProperties.java
@@ -25,6 +25,8 @@ import java.util.LinkedList;
 // import java.util.Scanner;
 import java.util.List;
 
+// Java language imports
+import java.lang.String;
 
 public class AppBundleProperties {
 
@@ -80,6 +82,7 @@ public class AppBundleProperties {
 
     // Explicit default: 1.3+
     private String mJVMVersion = "1.3+";
+	private double mJavaVersion = 1.3;
 
     // Explicit default: 6.0
     private final String mCFBundleInfoDictionaryVersion = "6.0";
@@ -443,12 +446,20 @@ public class AppBundleProperties {
     }
 
     public void setJVMVersion(String s) {
+	    s = s.trim();
         mJVMVersion = s;
+		String foodle = s.endsWith("+") ? s.substring(0, s.length()-1)
+		                                : s.substring(0, s.length());
+		mJavaVersion = Double.parseDouble(foodle);
     }
 
     public String getJVMVersion() {
         return mJVMVersion;
     }
+
+	public double getJavaVersion() {
+		return mJavaVersion;
+	}
 
     public void setVMOptions(String s) {
         mVMOptions = s;

--- a/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
+++ b/core/src/main/java/com/ultramixer/jarbundler/JarBundler.java
@@ -502,6 +502,9 @@ public class JarBundler extends MatchingTask {
      * @param b True sets 'JavaX' dictionary key instead of 'Java' key
      */
     public void setUseJavaXKey(boolean b) {
+		if (b && (bundleProperties.getJavaVersion() >= 1.7)) {
+			throw new BuildException("Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used");
+		}
         bundleProperties.setJavaXKey(b);
     }
 
@@ -512,8 +515,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If set to true, tab controls in Swing applications more closely resemble the Metal look and feel.
      */
+	@Deprecated
     public void setSmallTabs(boolean b) {
-        bundleProperties.addJavaProperty("com.apple.smallTabs", new Boolean(b)
+		bundleProperties.addJavaProperty("com.apple.smallTabs", Boolean.valueOf(b)
                 .toString());
     }
 
@@ -533,8 +537,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If set to true, use anti-aliasing when rendering graphics.
      */
+	@Deprecated
     public void setAntialiasedgraphics(boolean b) {
-        mAntiAliasedGraphics = new Boolean(b);
+		mAntiAliasedGraphics = Boolean.valueOf(b);
     }
 
     /**
@@ -544,8 +549,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If set to true, use anti-aliasing when rendering text.
      */
+	@Deprecated
     public void setAntialiasedtext(boolean b) {
-        mAntiAliasedText = new Boolean(b);
+		mAntiAliasedText = Boolean.valueOf(b);
     }
 
     /**
@@ -555,8 +561,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If set to true, puts Swing menus in the Mac OS X menu bar if using the Aqua look and feel.
      */
+	@Deprecated
     public void setScreenmenu(boolean b) {
-        mScreenMenuBar = new Boolean(b);
+		mScreenMenuBar = Boolean.valueOf(b);
     }
 
     /**
@@ -566,8 +573,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b Show the Aqua resize (grow) box.
      */
+	@Deprecated
     public void setGrowbox(boolean b) {
-        mGrowbox = new Boolean(b);
+		mGrowbox = Boolean.valueOf(b);
     }
 
     /**
@@ -577,8 +585,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If turned off, the bottom of the window is pushed down 15 pixels.
      */
+	@Deprecated
     public void setGrowboxintrudes(boolean b) {
-        mGrowboxIntrudes = new Boolean(b);
+		mGrowboxIntrudes = Boolean.valueOf(b);
     }
 
     /**
@@ -588,8 +597,9 @@ public class JarBundler extends MatchingTask {
      *
      * @param b If set to true, enable live-resizing of windows.
      */
+	@Deprecated
     public void setLiveresize(boolean b) {
-        mLiveResize = new Boolean(b);
+		mLiveResize = Boolean.valueOf(b);
     }
 
     /**
@@ -599,6 +609,7 @@ public class JarBundler extends MatchingTask {
      *
      * @param s The Mac OS type of the bundle.
      */
+	@Deprecated
     public void setType(String s) {
         bundleProperties.setCFBundlePackageType(s);
     }
@@ -619,6 +630,9 @@ public class JarBundler extends MatchingTask {
      */
     public void setJvmversion(String s) {
         bundleProperties.setJVMVersion(s);
+		if (bundleProperties.getJavaXKey() && (bundleProperties.getJavaVersion() >= 1.7)) {
+			throw new BuildException("Setting usejavaxkey is useless if jvmversion is at least 1.7, because then the Oracle PList format is used");
+		}
     }
 
 
@@ -657,7 +671,7 @@ public class JarBundler extends MatchingTask {
      * @param b true to start on JVM main thread
      */
     public void setStartonmainthread(boolean b) {
-        bundleProperties.setStartOnMainThread(new Boolean(b));
+		bundleProperties.setStartOnMainThread(Boolean.valueOf(b));
     }
 
 
@@ -667,7 +681,7 @@ public class JarBundler extends MatchingTask {
      * @param b ???
      */
     public void setIsAgent( boolean b ) {
-        bundleProperties.setLSUIElement( new Boolean( b ) );
+		bundleProperties.setLSUIElement(Boolean.valueOf(b));
     }
 
 
@@ -755,6 +769,7 @@ public class JarBundler extends MatchingTask {
      *
      * @param s A list of jar files or patternsets (space or comma seperated)
      */
+	@Deprecated
     public void setJars(String s) {
         PatternSet patset = new PatternSet();
         patset.setIncludes(s);
@@ -770,6 +785,7 @@ public class JarBundler extends MatchingTask {
      *
      * @param s A single jar file to be used in your application.
      */
+	@Deprecated
     public void setJar(File s) {
         mJarAttrs.add(s);
     }
@@ -781,6 +797,7 @@ public class JarBundler extends MatchingTask {
      *
      * @param s A list of files or patternsets (space or comma seperated)
      */
+	@Deprecated
     public void setExecs(String s) {
         PatternSet patset = new PatternSet();
         patset.setIncludes(s);
@@ -818,6 +835,7 @@ public class JarBundler extends MatchingTask {
      *
      * @param s File to chmod
      */
+	@Deprecated
     public void setChmod(String s) {
         log("The \"chmod\" attribute is deprecated, use the ANT Chmod task instead");
     }
@@ -1128,7 +1146,7 @@ public class JarBundler extends MatchingTask {
                     + mResourcesDir);
 
         // Make the Resources/Java directory
-        mJavaDir = new File(mResourcesDir, "Java");
+		mJavaDir = new File(bundleProperties.getJavaVersion() < 1.7 ? mResourcesDir : mContentsDir, "Java");
 
         if (!mJavaDir.mkdir())
             throw new BuildException("Unable to create directory " + mJavaDir);
@@ -1253,7 +1271,7 @@ public class JarBundler extends MatchingTask {
      * Obviously, this logic may need refactoring in the future.
      */
     private boolean useOldPropertyNames() {
-        return (bundleProperties.getJVMVersion().startsWith("1.3"));
+		return (bundleProperties.getJavaVersion() <= 1.3);
     }
 
     private void processJarAttrs() throws BuildException {


### PR DESCRIPTION
I've used jarbundler for years in jape. For a while we could exist using java versions 1.7 and below, but changes to the way Java deals with macOS UI actions mean that we couldn't use 1.8 and had to switch to 1.9 and above. Jarbundler didn't (and, I think, still doesn't) deal with modern version numbering (e.g. 9+) and, when compiled with modern java versions, has lots of deprecated stuff (and even very old stuff that isn't usable in modern java versions).

This pull request works with modern javas (9 and above) both in compilation and execution. It parses the version specification correctly; it puts the java version in the Oracle plist; and it deprecates what should be deprecated. It works up to Big Sur and java 13.